### PR TITLE
Dynamic AWS account number lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .glide/
 
 vendor/
+vault-vouch

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ The only supported Trusted Third Party is currently AWS IAM.
 
 ## Usage
 
-| Command Argument   | Environment Variable | Default | Description                                                |
-|--------------------|----------------------|---------|------------------------------------------------------------|
-| `-role=`           | `IV_ROLE`            | `nil`   | Role to request from Vault                                 |
-| `-aws_arn_role=`   | `IV_AWS_ARN_ROLE`    | `nil`   | AWS role to assume before preparing auth payload for Vault |
-| `-vault_addr=`     | `IV_VAULT_ADDR`      | `nil`   | Vault address                                              |
-| `-wrap_token_ttl=` | `IV_WRAP_TOKEN_TTL`  | `5m`    | TTL for wrapped token, to disable wrapping set to `0`      |
+| Command Argument   | Environment Variable | Default | Description                                                                                             |
+|--------------------|----------------------|---------|---------------------------------------------------------------------------------------------------------|
+| `-role=`           | `IV_ROLE`            | `nil`   | Role to request from Vault                                                                              |
+| `-aws_arn_role=`   | `IV_AWS_ARN_ROLE`    | `nil`   | ARN of AWS role to use for auth payload for Vault                                                       |
+| `-aws_role=`       | `IV_AWS_ROLE`        | `nil`   | AWS role to use for auth payload for Vault - it uses the current account's credentials to build the ARN |
+| `-vault_addr=`     | `IV_VAULT_ADDR`      | `nil`   | Vault address                                                                                           |
+| `-wrap_token_ttl=` | `IV_WRAP_TOKEN_TTL`  | `5m`    | TTL for wrapped token, to disable wrapping set to `0`                                                   |
 
 ## Example
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,8 @@ import (
 var (
 	fs           = flag.NewFlagSetWithEnvPrefix(os.Args[0], "IV", 0)
 	Role         = fs.String("role", "", "Role to request from Vault")
-	AwsArnRole   = fs.String("aws_arn_role", "", "AWS role to assume before preparing auth payload for Vault")
+	AwsArnRole   = fs.String("aws_arn_role", "", "ARN of AWS role to assume before preparing auth payload for Vault")
+	AwsRole      = fs.String("aws_role", "", "Name of AWS role on current account to assume before preparing auth payload for Vault")
 	VaultAddress = fs.String("vault_addr", "", "Vault address")
 	WrapTokenTTL = fs.String("wrap_token_ttl", "5m", "TTL for wrapped token")
 )
@@ -36,7 +37,9 @@ func main() {
 	}
 	var gen vault.Generator
 	if *AwsArnRole != "" {
-		gen = aws.AssumeRoleGenerator(*VaultAddress, *AwsArnRole)
+		gen = aws.AssumeRoleArnGenerator(*VaultAddress, *AwsArnRole)
+	} else if *AwsRole != "" {
+		gen = aws.AssumeRoleGenerator(*VaultAddress, *AwsRole)
 	} else {
 		gen = aws.DefaultGenerator(*VaultAddress)
 	}


### PR DESCRIPTION
This allows you to specify the name of a role on AWS to assume without an account number. It will use the default credential provider's account number to create the ARN.